### PR TITLE
Use polygons for reveal structures

### DIFF
--- a/mspray/apps/reveal/common_tags.py
+++ b/mspray/apps/reveal/common_tags.py
@@ -1,3 +1,4 @@
 """common tags module for reveal app"""
 
 NOT_PROVIDED = "not provided"
+POLYGON = "Polygon"

--- a/mspray/apps/reveal/serializers.py
+++ b/mspray/apps/reveal/serializers.py
@@ -50,7 +50,7 @@ class HouseholdSerializer(LocationSerializer):
 
     class Meta:
         model = Household
-        geo_field = "geom"
+        geo_field = "bgeom"
         fields = ["id", "name", "status", "parentId", "geographicLevel"]
 
     def get_name(self, obj):  # pylint: disable=unused-argument

--- a/mspray/apps/reveal/settings.py
+++ b/mspray/apps/reveal/settings.py
@@ -7,7 +7,7 @@ REVEAL_SPRAY_STATUS_FIELD = getattr(settings, "REVEAL_SPRAY_STATUS_FIELD",
                                     "task_business_status")
 REVEAL_SPRAYED_VALUE = getattr(settings, "REVEAL_SPRAYED_VALUE", "Sprayed")
 REVEAL_NOT_SPRAYED_VALUE = getattr(settings, "REVEAL_NOT_SPRAYED_VALUE",
-                                   "Not Sprayed - Refused")
+                                   "Not Sprayed")
 REVEAL_NOT_VISITED_VALUE = getattr(settings, "REVEAL_NOT_VISITED_VALUE",
                                    "Not Visited")
 REVEAL_NOT_SPRAYABLE_VALUE = getattr(settings, "REVEAL_NOT_SPRAYABLE_VALUE",

--- a/mspray/apps/reveal/tests/test_serializers.py
+++ b/mspray/apps/reveal/tests/test_serializers.py
@@ -40,12 +40,14 @@ class TestSerializers(TestBase):
         self.assertEqual("MultiPolygon", data["geometry"]["type"])
 
         self.assertDictEqual(
-            OrderedDict([
-                ("name", "Chadiza"),
-                ("status", "Active"),
-                ("parentId", None),
-                ("geographicLevel", 0),
-            ]),
+            OrderedDict(
+                [
+                    ("name", "Chadiza"),
+                    ("status", "Active"),
+                    ("parentId", None),
+                    ("geographicLevel", 0),
+                ]
+            ),
             data["properties"],
         )
 
@@ -64,15 +66,17 @@ class TestSerializers(TestBase):
         self.assertEqual("Feature", data["type"])
         self.assertEqual("Polygon", data["geometry"]["type"])
 
-        self.assertEqual(house.bgeom,
-                         GEOSGeometry(json.dumps(data['geometry'])))
+        self.assertEqual(
+            house.bgeom, GEOSGeometry(json.dumps(data["geometry"])))
 
         self.assertDictEqual(
-            OrderedDict([
-                ("name", None),
-                ("status", "Active"),
-                ("parentId", house.location.id),
-                ("geographicLevel", 4),
-            ]),
+            OrderedDict(
+                [
+                    ("name", None),
+                    ("status", "Active"),
+                    ("parentId", house.location.id),
+                    ("geographicLevel", 4),
+                ]
+            ),
             data["properties"],
         )

--- a/mspray/apps/reveal/tests/test_serializers.py
+++ b/mspray/apps/reveal/tests/test_serializers.py
@@ -1,6 +1,8 @@
 """module to test reveal Serializers"""
+import json
 from collections import OrderedDict
 
+from django.contrib.gis.geos import GEOSGeometry
 from django.test import override_settings
 
 from mspray.apps.main.models import Household, Location
@@ -60,7 +62,10 @@ class TestSerializers(TestBase):
 
         self.assertEqual(house.id, data["id"])
         self.assertEqual("Feature", data["type"])
-        self.assertEqual("Point", data["geometry"]["type"])
+        self.assertEqual("Polygon", data["geometry"]["type"])
+
+        self.assertEqual(house.bgeom,
+                         GEOSGeometry(json.dumps(data['geometry'])))
 
         self.assertDictEqual(
             OrderedDict([

--- a/mspray/apps/reveal/tests/test_utils.py
+++ b/mspray/apps/reveal/tests/test_utils.py
@@ -100,10 +100,10 @@ class TestUtils(TestBase):
         """
         SprayDay.objects.all().delete()
         input_data = {
-            'id': '154147',
-            'parent_id': '3951',
-            'status': 'Active',
-            'geometry': """{
+            "id": "154147",
+            "parent_id": "3951",
+            "status": "Active",
+            "geometry": """{
                 "type":"Polygon",
                 "coordinates":[
                     [
@@ -117,14 +117,14 @@ class TestUtils(TestBase):
                     ]
                 ]
             }""",
-            'server_version': 1545204913897,
-            'task_id': 'd6058db2-0364-11e9-8eb2-f2801f1b9fd1',
-            'task_spray_operator': 'demoMTI',
-            'task_status': 'Ready',
+            "server_version": 1545204913897,
+            "task_id": "d6058db2-0364-11e9-8eb2-f2801f1b9fd1",
+            "task_spray_operator": "demoMTI",
+            "task_status": "Ready",
             "task_business_status": "Sprayed",
             "task_execution_start_date": "2015-09-21T1000",
-            'task_execution_end_date': '',
-            'task_server_version': 1545206825909
+            "task_execution_end_date": "",
+            "task_server_version": 1545206825909,
         }
         add_spray_data(data=input_data)
         self.assertEqual(1, SprayDay.objects.all().count())
@@ -217,10 +217,10 @@ class TestUtils(TestBase):
         SprayDay.objects.all().delete()
 
         input_data = {
-            'id': '154147',
-            'parent_id': '3951',
-            'status': 'Active',
-            'geometry': """{
+            "id": "154147",
+            "parent_id": "3951",
+            "status": "Active",
+            "geometry": """{
                 "type":"Polygon",
                 "coordinates":[
                     [
@@ -240,21 +240,22 @@ class TestUtils(TestBase):
                     ]
                 ]
             }""",
-            'server_version': 1545204913897,
-            'task_id': 'd6058db2-0364-11e9-8eb2-f2801f1b9fd1',
-            'task_spray_operator': 'demoMTI',
-            'task_status': 'Ready',
+            "server_version": 1545204913897,
+            "task_id": "d6058db2-0364-11e9-8eb2-f2801f1b9fd1",
+            "task_spray_operator": "demoMTI",
+            "task_status": "Ready",
             "task_business_status": "Sprayed",
             "task_execution_start_date": "2015-09-21T1000",
-            'task_execution_end_date': '',
-            'task_server_version': 1545206825909
+            "task_execution_end_date": "",
+            "task_server_version": 1545206825909,
         }
 
         # we are deleting this household so that it is not found when
         # attempting to link the spray data to a structure
         Household.objects.filter(
             bgeom__contains=GEOSGeometry(
-                input_data.get(settings.REVEAL_GPS_FIELD)).centroid
+                input_data.get(settings.REVEAL_GPS_FIELD)
+            ).centroid
         ).first().delete()
 
         add_spray_data(data=input_data)
@@ -264,8 +265,8 @@ class TestUtils(TestBase):
         self.assertEqual(1, sprayday.submission_id)
         self.assertEqual(date(2015, 9, 21), sprayday.spray_date)
         self.assertEqual(
-            Point(float(28.352047248865144),
-                  float(-15.418157849354216)).coords,
+            Point(
+                float(28.352047248865144), float(-15.418157849354216)).coords,
             sprayday.geom.coords,
         )
         self.assertTrue(sprayday.bgeom is not None)

--- a/mspray/apps/reveal/tests/test_utils.py
+++ b/mspray/apps/reveal/tests/test_utils.py
@@ -12,6 +12,7 @@ from mspray.apps.reveal.utils import add_spray_data
 REVEAL_SPRAY_STATUS_FIELD = "task_business_status"
 REVEAL_NOT_SPRAYABLE_VALUE = "Not Sprayable"
 REVEAL_SPRAYED_VALUE = "Sprayed"
+REVEAL_NOT_SPRAYED_VALUE = "Not Sprayed"
 REVEAL_DATE_FIELD = "task_execution_start_date"
 
 
@@ -19,6 +20,7 @@ REVEAL_DATE_FIELD = "task_execution_start_date"
     REVEAL_SPRAY_STATUS_FIELD=REVEAL_SPRAY_STATUS_FIELD,
     REVEAL_NOT_SPRAYABLE_VALUE=REVEAL_NOT_SPRAYABLE_VALUE,
     REVEAL_SPRAYED_VALUE=REVEAL_SPRAYED_VALUE,
+    REVEAL_NOT_SPRAYED_VALUE=REVEAL_NOT_SPRAYED_VALUE,
     REVEAL_DATE_FIELD=REVEAL_DATE_FIELD,
     REVEAL_GPS_FIELD="geometry",
     MSPRAY_OSM_PRESENCE_FIELD=False,
@@ -281,6 +283,39 @@ class TestUtils(TestBase):
         add_spray_data(data=input_data)
         self.assertEqual(1, SprayDay.objects.all().count())
 
+    def test_add_spray_data_not_sprayed_refused(self):
+        """
+        Test add_spray_data REFUSED for reveal
+        """
+        SprayDay.objects.all().delete()
+        input_data = {
+            "id": "1337",
+            "parent_id": "3537",
+            "status": "Active",
+            "geometry": """{
+                "type": "Point",
+                "coordinates": [
+                    28.35517894260948,-15.41818400162254
+                ]}""",
+            "server_version": 1542970626309,
+            "task_id": "2caa810d-d4da-4e67-838b-badb9bd86e06",
+            "task_spray_operator": "demoMTI",
+            "task_status": "Ready",
+            "task_business_status": "Not Sprayed - Refused",
+            "task_execution_start_date": "2015-09-21T1000",
+            "task_execution_end_date": "2015-09-21T1100",
+            "task_server_version": 1543867945196,
+        }
+        add_spray_data(data=input_data)
+        self.assertEqual(1, SprayDay.objects.all().count())
+        sprayday = SprayDay.objects.first()
+        self.assertEqual(sprayday.osmid, sprayday.household.hh_id)
+        self.assertFalse(sprayday.was_sprayed)
+        self.assertTrue(sprayday.sprayable)
+        self.assertTrue(sprayday.household.visited)
+        self.assertTrue(sprayday.household.sprayable)
+        self.assertTrue(SprayPoint.objects.filter(sprayday=sprayday).exists())
+
     def test_add_spray_data_not_sprayed(self):
         """
         Test add_spray_data NOT SPRAYED for reveal
@@ -299,7 +334,7 @@ class TestUtils(TestBase):
             "task_id": "2caa810d-d4da-4e67-838b-badb9bd86e06",
             "task_spray_operator": "demoMTI",
             "task_status": "Ready",
-            "task_business_status": "Not Sprayed - Refused",
+            "task_business_status": "Not Sprayed",
             "task_execution_start_date": "2015-09-21T1000",
             "task_execution_end_date": "2015-09-21T1100",
             "task_server_version": 1543867945196,

--- a/mspray/apps/reveal/tests/test_views.py
+++ b/mspray/apps/reveal/tests/test_views.py
@@ -45,7 +45,8 @@ class TestViews(TestBase):
             "task_server_version": 1543867945196
         }"""  # noqa
         request = self.factory.post(
-            "add-spray-data", data=payload, content_type="application/json")
+            "add-spray-data", data=payload, content_type="application/json"
+        )
         res = add_spray_data_view(request)
 
         # we got the right response
@@ -88,7 +89,8 @@ class TestViews(TestBase):
             "task_server_version": 1545206825909
         }"""  # noqa
         request = self.factory.post(
-            "add-spray-data", data=payload, content_type="application/json")
+            "add-spray-data", data=payload, content_type="application/json"
+        )
         res = add_spray_data_view(request)
 
         # we got the right response

--- a/mspray/apps/reveal/tests/test_views.py
+++ b/mspray/apps/reveal/tests/test_views.py
@@ -82,8 +82,8 @@ class TestViews(TestBase):
             "task_id": "d6058db2-0364-11e9-8eb2-f2801f1b9fd1",
             "task_spray_operator": "demoMTI",
             "task_status": "Ready",
-            "task_business_status": "Not Visited",
-            "task_execution_start_date": "2018-11-10T2200",
+            "task_business_status": "Sprayed",
+            "task_execution_start_date": "2015-09-21T1000",
             "task_execution_end_date": "",
             "task_server_version": 1545206825909
         }"""  # noqa

--- a/mspray/apps/reveal/utils.py
+++ b/mspray/apps/reveal/utils.py
@@ -47,7 +47,8 @@ def add_spray_data(data: dict):
         except SprayDay.DoesNotExist:
             # generate a new id by incrementing the last one we received
             last = SprayDay.objects.all().aggregate(
-                last_id=Coalesce(Max("submission_id"), 0))
+                last_id=Coalesce(Max("submission_id"), 0)
+            )
             submission_id = last["last_id"] + 1
         else:
             submission_id = existing.submission_id
@@ -76,14 +77,16 @@ def add_spray_data(data: dict):
         if geometry.geom_type == POLYGON:
             location = Location.objects.filter(
                 geom__contains=geometry.centroid,
-                level=settings.MSPRAY_TA_LEVEL).first()
+                level=settings.MSPRAY_TA_LEVEL
+            ).first()
         else:
             location = Location.objects.filter(
-                geom__contains=geometry,
-                level=settings.MSPRAY_TA_LEVEL).first()
+                geom__contains=geometry, level=settings.MSPRAY_TA_LEVEL
+            ).first()
 
         sprayday, _ = SprayDay.objects.get_or_create(
-            submission_id=submission_id, spray_date=spray_date)
+            submission_id=submission_id, spray_date=spray_date
+        )
 
         sprayday.data = data
         sprayday.save()


### PR DESCRIPTION
This PR ensures that reveal data received in the form of Polygons as opposed to Points will still work as expected.